### PR TITLE
feat: add login & logout functionality

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -1,5 +1,7 @@
 const CONFIG = {
     chain_id: 1075,
     evm_node: "https://we.addiota.com",
-    contract_posts_address: "0xd68E91FaafBC240daC4d1dEA58971BD476C7c4A0"
+    contract_posts_address: "0xF79F25fCbb3600f3641b73f3cbd9eaE3c0C8B4c0",
+    whitelist: "./whitelist",
+    blacklist: "./blacklist"
 }

--- a/app/css/style.css
+++ b/app/css/style.css
@@ -14,6 +14,10 @@ html .bg-decensored {
     background-color: #3833a4;
 }
 
+html .bg-decensored-secondary {
+    background-color: #E45B18;
+}
+
 html .bg-decensored-gradient {
     background-color: #3833a4;
     background: rgb(57,56,161);

--- a/app/js/helper.js
+++ b/app/js/helper.js
@@ -5,7 +5,7 @@ async function get_balance(address) {
     });
 }
 
-async function close_screen_signup_if_complete() {
+async function close_screen_signup_if_complete(action) {
     if(await is_signed_up()) {
         get_username().then(username => {
             message = $('#message');
@@ -14,6 +14,9 @@ async function close_screen_signup_if_complete() {
             $('#message').fadeTo( "fast" , 1);
         });
         $('#screen_sign_up').fadeOut();
+        $('.hideForLoggedOutUser').show();
+    } else if (action == 'loadCredentials') {
+        $("#error").html("Error: couldnt find a user with these credentials!");
     } else {
         setTimeout(function() {
             $('#screen_sign_up').fadeIn();

--- a/app/js/init.js
+++ b/app/js/init.js
@@ -21,6 +21,7 @@ $(document).ready(async () => {
     $("#init-overlay").load("./templates/overlay.html", async () => {
         $("#overlay").unwrap();
         $('#chain_id').text(CONFIG.chain_id);
+        $('.hideForLoggedOutUser').hide();
 
         let contract_accounts_address = await contract_posts.methods.accounts().call();
         contract_accounts = new web3.eth.Contract(CONTRACT_ACCOUNTS_ABI, contract_accounts_address);
@@ -34,6 +35,7 @@ $(document).ready(async () => {
             if(profile_username && username !== profile_username) {
                 $('#input').css("display", "none");
                 $('#feed > .container').prepend($("<div class='text-center text-xl font-bold mb-5'></div>").addClass("profile_title").text(profile_username));
+                $('.hideForLoggedOutUser').show();
             }
 
             $('#profile').attr('href', "?u="+username);

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -97,6 +97,11 @@ async function is_signed_up() {
     );
 }
 
+async function sign_out() {
+    localStorage.removeItem('account_private_key');
+    location.reload();
+}
+
 async function execute_contract_function(web3, function_call) {
     let privateKey = get_private_key();
     const account_address = web3.eth.accounts.privateKeyToAccount(privateKey).address;
@@ -123,6 +128,18 @@ async function on_sign_up_button_pressed() {
         .then(async _ => { await close_screen_signup_if_complete() })
         .catch(error => { alert(error) })
 }
+
+async function on_private_key_inserted() {
+    let privateKey = $('#privateKey').val();
+    localStorage.setItem('account_private_key', privateKey);
+    close_screen_signup_if_complete('loadCredentials');
+}
+
+async function copy_credentials_to_clipboard() {
+    const privateKey = localStorage.getItem('account_private_key');
+    navigator.clipboard.writeText(privateKey);
+}
+
 
 function get_address() {
     let private_key = get_private_key();

--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -2,9 +2,12 @@
     <div class="flex gap-y-5 p-4 justify-between items-center">
         <img class="h-10" src="images/logo/signet.svg"/>
         <div class="text-gray-400 text-sm pointer-events-auto">
-            <a href="https://github.com/mikrohash/decensored" target="_blank">github</a>
+            <a href="https://github.com/mikrohash/decensored" target="_blank"><i class="fab fa-github fa-lg"></i></a>
             <span class="mx-2">|</span>
-            <a href="https://t.co/Lmou3Qx5Ap" target="_blank">Discord</a>
+            <a href="https://t.co/Lmou3Qx5Ap" target="_blank"><i class="fab fa-discord fa-lg"></i></a>
+            <span class="mx-2 hideForLoggedOutUser">|</span>
+            <button class="bg-decensored hover:bg-purple-800 text-white font-medium py-2 px-3 rounded cursor-pointer hideForLoggedOutUser" onclick="copy_credentials_to_clipboard()">Copy Credentials</button>
+            <button class="bg-decensored-secondary hover:bg-orange-800 text-white font-medium py-2 px-3 rounded cursor-pointer hideForLoggedOutUser" onclick="sign_out()"><i class="fas fa-sign-out-alt"></i></button>
         </div>
     </div>
 </div>

--- a/app/templates/overlay.html
+++ b/app/templates/overlay.html
@@ -5,9 +5,14 @@
             <img src="images/logo/logotype_invert.svg"/>
             <h1 class="text-white text-center text-2xl mb-5">Sign-up</h1>
             <div class="flex gap-3">
-                <input class="form-input p-3 rounded grow" type="text" placeholder="your username" id="username">
+                <input class="form-input p-3 rounded grow" type="text" placeholder="Choose your username" id="username">
                 <button class="bg-purple-500 hover:bg-purple-700 text-white font-bold py-3 px-4 rounded" onclick="on_sign_up_button_pressed()">Go</button>
             </div>
+            <div class="flex gap-3">
+                <input class="form-input p-3 rounded grow" type="text" placeholder="Paste in your key" id="privateKey">
+                <button class="bg-purple-500 hover:bg-purple-700 text-white font-bold py-3 px-4 rounded" onclick="on_private_key_inserted()">Go</button>
+            </div>
+            <span id="error" style="color: red"></span>
         </div>
     </div>
     <!--


### PR DESCRIPTION
**Description**:
This PR adds basic functionality for being able to copy your key after signing up and using it to login after full-refreshing your browser or on any other device. I've used the already existing function `close_screen_signup_if_complete` which basically takes care of checking if the login worked and displaying an error if not 👌 

It also hides the "create a post form" and the button to copy your key as long as you are not logged in + you are also now able to logout.

**What I've tested**:
- Creating a user still works 
- Copying your key to the clipboard 
- Logout your current user   
- Login with your private key 
- Display an error when no user with this key exists
- Hide login relevant stuff when logged out 