### PR TITLE
feat: add blacklisting / block users functionality

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -20,10 +20,11 @@
     <script type="text/javascript" src="node_modules/autosize/dist/autosize.min.js"></script>
     <script type="text/javascript" src="node_modules/cssuseragent/cssua.js"></script>
 
+    <script src="https://decensored.app/config.js"></script>
+    <script src="plugins/block_users/init.js"></script>
     <script src="plugins/private_key_recovery/init.js"></script>
     <script src="plugins/settings/init.js"></script>
 
-    <script src="https://decensored.app/config.js"></script>
     <script src="js/contract_abis.js"></script>
     <script src="js/post_fetcher.js"></script>
     <script src="js/init.js"></script>

--- a/app/js/init.js
+++ b/app/js/init.js
@@ -99,6 +99,7 @@ function init_overlay() {
 }
 
 function init_plugins() {
+    init_block_users();
     init_private_key_recovery();
     init_settings();
 }

--- a/app/js/main.js
+++ b/app/js/main.js
@@ -19,7 +19,10 @@ function get_profile_username() {
 async function load_posts_within_index_range(index_from, index_to) {
     for(let i = index_from; i <= index_to; i++) {
         post_fetcher.get_post(i).then(post => {
-            append_post_to_feed(post);
+            const blockedByUser = is_user_in_blacklist(post['author']);
+            if(!blockedByUser) {
+                append_post_to_feed(post);
+            }
         });
     }
 }
@@ -46,20 +49,21 @@ function generate_$post_meta(author_username, timestamp) {
         // ));
 }
 
-function generate_post_interaction_icon(icon, title) {
+function generate_post_interaction_icon(icon, title, action) {
     let $post_interaction_icon = $new_el_with_attr("i", "fas cursor-pointer text-gray-300 hover:text-gray-900 dark:text-gray-500 dark:hover:text-gray-300");
     $post_interaction_icon.addClass(icon);
     $post_interaction_icon.attr('title', title);
+    $post_interaction_icon.attr('onClick', action);
 
     return $post_interaction_icon;
 }
 
-function generate_post_interactions() {
+function generate_post_interactions(author, username) {
     let $wrapper = $new_el_with_attr("div", "px-5 py-3 rounded-b flex justify-between");
     let $left = $new_el_with_attr("div", "flex gap-x-3 items-center");
     let $right = $new_el_with_attr("div", "flex gap-x-3 items-center");
 
-    let $block_user = generate_post_interaction_icon('fa-shield-alt', 'block user');
+    let $block_user = generate_post_interaction_icon('fa-shield-alt', 'block user', `on_block_user_pressed('${author}', '${username}')`);
     let $share_post = generate_post_interaction_icon('fa-share', 'share post');
     let $comment = generate_post_interaction_icon('fa-comment', 'comment');
 
@@ -82,7 +86,7 @@ async function generate_$post(post) {
     $post_content.append($post_meta);
     $post_content.append($new_el_with_attr("div", "message break-words mt-2").text(post['message'].substr(0, 280)));
     $post.append($post_content);
-    $post.append(generate_post_interactions());
+    $post.append(generate_post_interactions(post['author'], author_username));
 
     return $post;
 }
@@ -107,7 +111,11 @@ function submit_post_input() {
     let message = $message.val();
     $message.val("");
     set_post_input_char_count();
-    return execute_contract_function(web3, contract_posts.methods.submit_post(message));
+    if(message.length > 0) {
+        return execute_contract_function(web3, contract_posts.methods.submit_post(message));
+    } else {
+        alert("You cant send an empty message!");
+    }
 }
 
 function update_feed() {
@@ -155,6 +163,7 @@ async function on_sign_up_button_pressed() {
 
 async function on_sign_out_button_pressed() {
     remove_private_key();
+    remove_user_blacklist();
     location.reload();
 }
 

--- a/app/plugins/block_users/blocked_user_tags.html
+++ b/app/plugins/block_users/blocked_user_tags.html
@@ -1,0 +1,4 @@
+<div class="my-2">
+    <div class="text-xs text-gray-900 dark:text-gray-300 mb-2">Blacklisted Users</div>
+    <div id="blocked-user-tags" class="flex flex-wrap gap-x-2 gap-y-2"></div>
+</div>

--- a/app/plugins/block_users/init.js
+++ b/app/plugins/block_users/init.js
@@ -1,0 +1,73 @@
+function init_block_users() {
+    append_element_with_html_on_load( '#settings_dialog_inner', "./plugins/block_users/blocked_user_tags.html");
+}
+
+function create_blocked_user_tag(user) {
+    console.log(user);
+    let div = $new_el_with_attr("div", "flex gap-x-1 items-center uppercase bg-decensored-100 text-gray-600 text-xs tracking-wide font-semibold px-2 py-1 rounded-md");
+    div.attr("id", "blocked-user-#"+user.id);
+    let span = $new_el_with_attr("span", "flex-none uppercase bg-decensored-100 text-gray-600 text-xs tracking-wide font-semibold px-2 py-1 rounded-md pointer-events-none").text(user.name);
+    let xIcon = $new_el_with_attr("i", "fas fa-times text-xs opacity-50 hover:opacity-100 cursor-pointer pr-1");
+    xIcon.attr("onClick", 'remove_user_from_blacklist('+ user.id +');');  
+    return div.append(span).append(xIcon);
+}
+
+async function append_blocked_users_to_div() {
+    const users = get_user_blacklist();
+    console.log("test");
+    users.forEach(user => {
+        $('#blocked-user-tags').append(create_blocked_user_tag(user));
+    });
+}
+
+function on_block_user_pressed(author, username) {
+    add_user_to_blacklist(author, username);
+}
+
+function get_user_blacklist() {
+    return JSON.parse(localStorage.getItem('blacklist'));
+}
+
+function is_user_in_blacklist(author) {
+    const blacklist = get_user_blacklist();
+    if(blacklist) {
+        const check = blacklist.find(user => user.id === author);
+        if(check) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+
+function add_user_to_blacklist(author, username) {
+    let blacklist = get_user_blacklist();
+    if(!blacklist) {
+        blacklist = [{'id': author, 'name': username}];
+        update_user_blacklist(blacklist)
+    } else {
+        const userExistsAlready = is_user_in_blacklist(author);
+        if(!userExistsAlready) {
+            blacklist.push({'id': author, 'name': username});
+            update_user_blacklist(blacklist)
+        }
+     }
+}
+
+function remove_user_from_blacklist(author) {
+    let blacklist = get_user_blacklist();
+    if(blacklist) {
+        var newBlacklist = blacklist.filter(function(user) { return user.id != author }); 
+        update_user_blacklist(newBlacklist);
+        console.log("#blocked-user-#"+author);
+        $("#blocked-user-#"+author).hide();
+    } 
+}
+
+function update_user_blacklist(blacklist) {
+    localStorage.setItem('blacklist', JSON.stringify(blacklist));
+}
+
+function remove_user_blacklist() {
+    return localStorage.removeItem('blacklist');
+}

--- a/app/plugins/settings/init.js
+++ b/app/plugins/settings/init.js
@@ -12,6 +12,8 @@ function toggle_settings_dialog() {
     set_body_scrolling(is_becoming_visible)
     $dialog.animate({ opacity: is_becoming_visible ? 1 : 0 }, 'fast');
     $dialog.toggleClass("hidden");
+    $("#blocked-user-tags").html('');
+    append_blocked_users_to_div();
 }
 
 function save_settings_dialog() {

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
     "./js/*.{html,js}",
     "./plugins/**/*.{html,js}",
     "./templates/*.{html,js}",
+    "./plugins/**/*.{html,js}",
     "./index.html"
   ],
   theme: {


### PR DESCRIPTION
**Description:**
First version of a user based blacklist. Users are now able to use the "block" icon to block them. Right now they are stored in the localStorage and updated each time a user gets blocked or unblocked.

**Todo later:**
- feed: hide the posts of users as soon as the user clicks on block
- settings: hide the blocked-usertag as soon as the user unblocks him in the settings
- storage: only store userId and query the username directly via the sc
- storage: store them inside the sc itself instead of the localStorage
- general: hide block icon for your own posts