### PR TITLE
feat: show / hide blocked users if they exist in feed

### DIFF
--- a/js/post.js
+++ b/js/post.js
@@ -55,6 +55,7 @@ function generate_post_interactions(author, username) {
 
 async function generate_$post(post) {
     let $post = $new_el_with_attr("div", "post bg-white dark:bg-gray-900 rounded divide-y divide-solid divide-gray-200 dark:divide-gray-800 shadow-sm").css("order", -post['timestamp']);
+    $post.attr("data-author", post['author']);
     let author_username = await contract_accounts.methods.username_by_id(post['author']).call();
     let $post_meta = generate_$post_meta(author_username, post['timestamp']);
     let $post_content = $new_el_with_attr("div", "rounded-t p-5");

--- a/plugins/block_users/init.js
+++ b/plugins/block_users/init.js
@@ -45,6 +45,7 @@ function is_user_in_blacklist(post) {
 }
 
 function add_user_to_blacklist(author, username) {
+    $("body").find(`[data-author='${author}']`).fadeOut(600);
     const blacklist = get_user_blacklist() || [];
     if (blacklist.find(user => user.id === author)) {
         return;
@@ -55,6 +56,7 @@ function add_user_to_blacklist(author, username) {
 }
 
 function remove_user_from_blacklist(author) {
+    $("body").find(`[data-author='${author}']`).fadeIn(600);
     let blacklist = get_user_blacklist();
     if(blacklist) {
         var newBlacklist = blacklist.filter(function(user) { return user.id != author });


### PR DESCRIPTION
This change hides posts of users as soon as you click on the shield-icon without refreshing the page!
If you remove them inside the settings the feed is checked and if post exist they will we shown again

Should close: https://github.com/mikrohash/decensored/issues/64
